### PR TITLE
Merch inv show app bd links

### DIFF
--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -23,6 +23,13 @@
       <p><b>Item Name:</b> <%= item.name %></p>
       <p><b>Quantity:</b> <%= invoice_item.quantity %></p>
       <p><b>Unit Price:</b> <%= invoice_item.unit_price %></p>
+
+      <% if invoice_item.find_item_discount.nil? %>
+        <p><b>Does Not Qualify for Discount</b></p>
+      <% else %>
+        <p><b>Discount Applied:</b> <%= link_to invoice_item.find_item_discount.id, merchant_bulk_discount_path(@merchant.id, invoice_item.find_item_discount.id) %></p>
+      <% end %>
+
       <%= form_with model: invoice_item do |f| %>
         <%= f.select :status, ['pending', 'packaged', 'shipped'], selected: invoice_item.status %>
         <%= f.submit "Update Item Status" %>

--- a/spec/features/merchant_invoices/show_spec.rb
+++ b/spec/features/merchant_invoices/show_spec.rb
@@ -108,5 +108,36 @@ RSpec.describe 'the merchant invoice show' do
         expect(page).to have_content("Total Discounted Revenue: $825.63")
       end
     end
+
+    it 'has links to the applied discount show next to each invoice item' do
+      invoice_item22 = InvoiceItem.create!(invoice_id: @invoice1.id, item_id: @item5.id, quantity: 1, unit_price: @item5.unit_price, status: 'shipped')
+      invoice_item23 = InvoiceItem.create!(invoice_id: @invoice1.id, item_id: @item17.id, quantity: 10, unit_price: @item17.unit_price, status: 'shipped')
+
+      visit merchant_invoice_path(@merchant1.id, @invoice1.id)
+
+      within("#item-#{@item1.id}") do
+        expect(page).to have_content("Discount Applied: #{@bulk_discount4.id}")
+        expect(page).to have_link(@bulk_discount4.id)
+      end
+
+      within("#item-#{@item15.id}") do
+        expect(page).to have_content("Discount Applied: #{@bulk_discount2.id}")
+        expect(page).to have_link(@bulk_discount2.id)
+      end
+
+      within("#item-#{@item16.id}") do
+        expect(page).to have_content("Discount Applied: #{@bulk_discount5.id}")
+        expect(page).to have_link(@bulk_discount5.id)
+      end
+
+      within("#item-#{@item5.id}") do
+        expect(page).to have_content("Does Not Qualify for Discount")
+      end
+
+      within("#item-#{@item17.id}") do
+        expect(page).to have_content("Discount Applied: #{@bulk_discount1.id}")
+        expect(page).to have_link(@bulk_discount1.id)
+      end
+    end
   end
 end

--- a/spec/features/merchant_invoices/show_spec.rb
+++ b/spec/features/merchant_invoices/show_spec.rb
@@ -109,6 +109,9 @@ RSpec.describe 'the merchant invoice show' do
       end
     end
 
+    # As a merchant
+    # When I visit my merchant invoice show page
+    # Next to each invoice item I see a link to the show page for the bulk discount that was applied (if any)
     it 'has links to the applied discount show next to each invoice item' do
       invoice_item22 = InvoiceItem.create!(invoice_id: @invoice1.id, item_id: @item5.id, quantity: 1, unit_price: @item5.unit_price, status: 'shipped')
       invoice_item23 = InvoiceItem.create!(invoice_id: @invoice1.id, item_id: @item17.id, quantity: 10, unit_price: @item17.unit_price, status: 'shipped')
@@ -120,12 +123,12 @@ RSpec.describe 'the merchant invoice show' do
         expect(page).to have_link(@bulk_discount4.id)
       end
 
-      within("#item-#{@item15.id}") do
+      within("#item-#{@item2.id}") do
         expect(page).to have_content("Discount Applied: #{@bulk_discount2.id}")
         expect(page).to have_link(@bulk_discount2.id)
       end
 
-      within("#item-#{@item16.id}") do
+      within("#item-#{@item3.id}") do
         expect(page).to have_content("Discount Applied: #{@bulk_discount5.id}")
         expect(page).to have_link(@bulk_discount5.id)
       end
@@ -137,7 +140,11 @@ RSpec.describe 'the merchant invoice show' do
       within("#item-#{@item17.id}") do
         expect(page).to have_content("Discount Applied: #{@bulk_discount1.id}")
         expect(page).to have_link(@bulk_discount1.id)
+
+        click_link(@bulk_discount1.id)
       end
+
+      expect(current_path).to eq(merchant_bulk_discount_path(@merchant1.id, @bulkdiscount1.id))
     end
   end
 end


### PR DESCRIPTION
What I did:
- Added links next to each invoice item on merchant invoice show page for applicable bulk discount applied to invoice item which redirects user to bulk discount show page

Roadblocks: None

Tests:
- All written tests passing
- Simplecov @ 98.6%

Notes:
- Moving onto admin invoice show page: total revenue and discounted revenue